### PR TITLE
Fix a typo (setted -> set)

### DIFF
--- a/lib/hob/world.rb
+++ b/lib/hob/world.rb
@@ -16,7 +16,7 @@ module Hob
       end
 
       def method_missing(method, *args, &block)
-        raise 'world was not setted up' unless @instance
+        raise 'world was not set up' unless @instance
         @instance.send(method, *args, &block)
       end
     end


### PR DESCRIPTION
Because _set_ is an irregular verb
